### PR TITLE
added mcc to cdf & s3df parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [0.12.0]
+
+### Changed
+
+- Updated `CDFParser` to parse merchant category codes in a CDF feed data.
+
 ## [0.11.0]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Updated `CDFParser` and `S3DFParser` to parse merchant category codes in a CDF feed data.
+- Updated `CDFParser` and `S3DFParser` to parse merchant category codes from the feed data.
 
 ## [0.11.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Updated `CDFParser` to parse merchant category codes in a CDF feed data.
+- Updated `CDFParser` and `S3DFParser` to parse merchant category codes in a CDF feed data.
 
 ## [0.11.0]
 

--- a/card_data_parsers/models/cdf_transaction.py
+++ b/card_data_parsers/models/cdf_transaction.py
@@ -6,6 +6,7 @@ from .transaction import Transaction
 class CDFTransaction(Transaction):
     nickname: str = None
 
+    merchant_category_code: str = None
     lodging_nights: int = None
     lodging_check_in_date: str = None
     lodging_checkout_date: str = None

--- a/card_data_parsers/models/s3df_transaction.py
+++ b/card_data_parsers/models/s3df_transaction.py
@@ -4,6 +4,7 @@ from .transaction import Transaction
 
 @dataclass
 class S3DFTransaction(Transaction):
+    merchant_category_code: str = None
     general_issuing_carrier: str = None
     general_travel_agency_name: str = None
     general_travel_agency_code: str = None

--- a/card_data_parsers/parsers/cdf_parser.py
+++ b/card_data_parsers/parsers/cdf_parser.py
@@ -110,6 +110,7 @@ class CDFParser(Parser):
         txn.vendor = CDFParser.__get_element_by_tag(
             card_acceptor, 'CardAcceptorName').text
 
+        # MCC
         txn.merchant_category_code = CDFParser.__get_element_by_tag(
             card_acceptor, 'CardAcceptorBusinessCode').text
 

--- a/card_data_parsers/parsers/cdf_parser.py
+++ b/card_data_parsers/parsers/cdf_parser.py
@@ -110,6 +110,9 @@ class CDFParser(Parser):
         txn.vendor = CDFParser.__get_element_by_tag(
             card_acceptor, 'CardAcceptorName').text
 
+        txn.merchant_category_code = CDFParser.__get_element_by_tag(
+            card_acceptor, 'CardAcceptorBusinessCode').text
+
         # Nickname
         if nickname is not None:
             txn.nickname = nickname

--- a/card_data_parsers/parsers/s3df_parser.py
+++ b/card_data_parsers/parsers/s3df_parser.py
@@ -117,6 +117,10 @@ class S3DFParser(Parser):
         txn.vendor = str(txn.vendor) + ', ' + S3DFParser.__get_element_by_tag(
             card_acceptor, 'CardAcceptorStateProvince').text
 
+        # MCC
+        txn.merchant_category_code = S3DFParser.__get_element_by_tag(
+            card_acceptor, 'CardAcceptorBusinessCode').text
+
         # external Id
         external_id = S3DFParser.__get_element_by_tag(
             ftrxn, 'ProcessorTransactionId').text

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='card_data_parsers',
-    version='0.11.0',
+    version='0.12.0',
     author='Siva Narayanan',
     author_email='siva@fyle.in',
     url='https://www.fylehq.com',

--- a/tests/card_data_parsers/cdf/p2/expected.json
+++ b/tests/card_data_parsers/cdf/p2/expected.json
@@ -6,6 +6,7 @@
     "amount": "13.99",
     "currency": "EUR",
     "vendor": "ABCDEF",
+    "merchant_category_code": "5968",
     "external_id": "bcc54fff373cf5b4eb1b3b8c53c111bf",
     "post_date": "2018-12-20T10:00:00.000000Z"
   },
@@ -16,6 +17,7 @@
     "amount": "130",
     "currency": "EUR",
     "vendor": "ABCDEF",
+    "merchant_category_code": "5399",
     "external_id": "c36c9ba0602a898336e1c08360495d5d",
     "post_date": "2018-12-20T10:00:00.000000Z"
   },
@@ -26,6 +28,7 @@
     "amount": "38.63",
     "currency": "EUR",
     "vendor": "ABCDEF",
+    "merchant_category_code": "4784",
     "external_id": "379e9c62e0804eeb9ff0864fb03b96f0",
     "post_date": "2018-12-20T10:00:00.000000Z"
   },
@@ -36,6 +39,7 @@
     "amount": "129",
     "currency": "EUR",
     "vendor": "ABCDEF",
+    "merchant_category_code": "5733",
     "external_id": "14a181d358d82b3dd3532e5ec47653d8",
     "post_date": "2018-12-20T10:00:00.000000Z"
   }

--- a/tests/card_data_parsers/cdf/p3/expected.json
+++ b/tests/card_data_parsers/cdf/p3/expected.json
@@ -6,6 +6,7 @@
     "amount": "5",
     "currency": "EUR",
     "vendor": "Abcd",
+    "merchant_category_code": "5541",
     "external_id": "516f72d0902bafeec0448b23a9735b94",
     "post_date": "2018-12-19T10:00:00.000000Z"
   },
@@ -16,6 +17,7 @@
     "amount": "3.89",
     "currency": "EUR",
     "vendor": "Abcd",
+    "merchant_category_code": "5541",
     "external_id": "7479ca62690d075b08a39e072df79c2a",
     "post_date": "2018-12-19T10:00:00.000000Z"
   },
@@ -26,6 +28,7 @@
     "amount": "89",
     "currency": "EUR",
     "vendor": "Abcdedfgh",
+    "merchant_category_code": "7011",
     "external_id": "79c952ed6c2e4fb3038a405dc494cade",
     "post_date": "2018-12-19T10:00:00.000000Z"
   }

--- a/tests/card_data_parsers/cdf/p4/expected.json
+++ b/tests/card_data_parsers/cdf/p4/expected.json
@@ -6,6 +6,7 @@
     "amount": "5",
     "currency": "EUR",
     "vendor": "Abcd",
+    "merchant_category_code": "5541",
     "external_id": "516f72d0902bafeec0448b23a9735b94",
     "post_date": "2018-12-19T10:00:00.000000Z"
   },
@@ -16,6 +17,7 @@
     "amount": "3.89",
     "currency": "EUR",
     "vendor": "Abcd",
+    "merchant_category_code": "5541",
     "external_id": "7479ca62690d075b08a39e072df79c2a",
     "post_date": "2018-12-19T10:00:00.000000Z"
   },
@@ -26,6 +28,7 @@
     "amount": "89",
     "currency": "EUR",
     "vendor": "Abcdedfgh",
+    "merchant_category_code": "7011",
     "external_id": "79c952ed6c2e4fb3038a405dc494cade",
     "post_date": "2018-12-19T10:00:00.000000Z"
   }

--- a/tests/card_data_parsers/s3df/p1/expected.json
+++ b/tests/card_data_parsers/s3df/p1/expected.json
@@ -6,6 +6,7 @@
     "amount": "294.97",
     "currency": "GBP",
     "vendor": "Abcd, --",
+    "merchant_category_code": "3811",
     "external_id": "5e65fcc2d8388da145d00043ce50dff9",
     "post_date": "2019-10-02T10:00:00.000000Z"
   },
@@ -16,6 +17,7 @@
     "amount": "109",
     "currency": "GBP",
     "vendor": "Abcd, --",
+    "merchant_category_code": "7011",
     "external_id": "739a85df06f04d7c823c3a9012cf05e3",
     "post_date": "2019-10-02T10:00:00.000000Z"
   },
@@ -26,6 +28,7 @@
     "amount": "2098.8",
     "currency": "GBP",
     "vendor": "PARK PLAZA LONDON WATE, --",
+    "merchant_category_code": "7011",
     "external_id": "bdafcb93370618638a43b53cc5880a28",
     "post_date": "2019-10-02T10:00:00.000000Z"
   },
@@ -36,6 +39,7 @@
     "amount": "5.64",
     "currency": "GBP",
     "vendor": "Abcd, --",
+    "merchant_category_code": "7011",
     "external_id": "1a9375ab8269860d6ee2c1c758f4694d",
     "post_date": "2019-10-02T10:00:00.000000Z"
   },
@@ -48,6 +52,7 @@
     "foreign_amount": "230.4",
     "foreign_currency": "EUR",
     "vendor": "Abcd, --",
+    "merchant_category_code": "7011",
     "external_id": "0205ba3ba7e22335177c2bb52e1bf68f",
     "post_date": "2019-10-02T10:00:00.000000Z"
   },
@@ -58,6 +63,7 @@
     "amount": "74",
     "currency": "GBP",
     "vendor": "Abcd, --",
+    "merchant_category_code": "7523",
     "external_id": "d331fbcc2d265d4d016b4f6ce76c66b9",
     "post_date": "2019-10-02T10:00:00.000000Z"
   },
@@ -68,6 +74,7 @@
     "amount": "74",
     "currency": "GBP",
     "vendor": "Abcd, --",
+    "merchant_category_code": "7523",
     "external_id": "9cf17c980e286b7f88b775d5bb343b18",
     "post_date": "2019-10-02T10:00:00.000000Z"
   }

--- a/tests/card_data_parsers/s3df/p2/expected.json
+++ b/tests/card_data_parsers/s3df/p2/expected.json
@@ -6,6 +6,7 @@
     "amount": "294.97",
     "currency": "GBP",
     "vendor": "Abcd, --",
+    "merchant_category_code": "3811",
     "external_id": "5e65fcc2d8388da145d00043ce50dff9",
     "post_date": "2019-10-02T10:00:00.000000Z"
   },
@@ -16,6 +17,7 @@
     "amount": "109",
     "currency": "GBP",
     "vendor": "Abcd, --",
+    "merchant_category_code": "7011",
     "external_id": "739a85df06f04d7c823c3a9012cf05e3",
     "post_date": "2019-10-02T10:00:00.000000Z"
   },
@@ -26,6 +28,7 @@
     "amount": "2098.8",
     "currency": "GBP",
     "vendor": "PARK PLAZA LONDON WATE, --",
+    "merchant_category_code": "7011",
     "external_id": "bdafcb93370618638a43b53cc5880a28",
     "post_date": "2019-10-02T10:00:00.000000Z"
   },
@@ -36,6 +39,7 @@
     "amount": "5.64",
     "currency": "GBP",
     "vendor": "Abcd, --",
+    "merchant_category_code": "7011",
     "external_id": "1a9375ab8269860d6ee2c1c758f4694d",
     "post_date": "2019-10-02T10:00:00.000000Z"
   },
@@ -48,6 +52,7 @@
     "foreign_amount": "230.4",
     "foreign_currency": "EUR",
     "vendor": "Abcd, --",
+    "merchant_category_code": "7011",
     "external_id": "0205ba3ba7e22335177c2bb52e1bf68f",
     "post_date": "2019-10-02T10:00:00.000000Z"
   },
@@ -58,6 +63,7 @@
     "amount": "74",
     "currency": "GBP",
     "vendor": "Abcd, --",
+    "merchant_category_code": "7523",
     "external_id": "d331fbcc2d265d4d016b4f6ce76c66b9",
     "post_date": "2019-10-02T10:00:00.000000Z"
   },
@@ -68,6 +74,7 @@
     "amount": "74",
     "currency": "GBP",
     "vendor": "Abcd, --",
+    "merchant_category_code": "7523",
     "external_id": "9cf17c980e286b7f88b775d5bb343b18",
     "post_date": "2019-10-02T10:00:00.000000Z"
   }


### PR DESCRIPTION
1. added `merchant_category_code` to `cdf_transaction.py`.
2. getting mcc in `cdf_parser.py` from key `CardAcceptorBusinessCode` in card_acceptor.
3. updated existing tests to check merchant_category_codes.
4. ^same for `S3DFParser` as well.
5. updated `CHANGELOG.md` and `setup.py`.