### PR TITLE
fix: FYLE-85ztdangu-vcf-parser-minor-fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [0.15.0]
+
+### Changed
+
+- Bug fixed in `VCFParser` to parse all transaction blocks present in a VCF feed data.
+
 ## [0.14.0]
 
 ### Changed

--- a/card_data_parsers/parsers/vcf_parser.py
+++ b/card_data_parsers/parsers/vcf_parser.py
@@ -214,27 +214,22 @@ class VCFParser(Parser):
                 car_rental_transactions_block_start = index + 1
             if line[0].strip() == '9' and (line[4].strip() == '02' or line[4].strip() == '2') and car_rental_transactions_block_end == -1:
                 car_rental_transactions_block_end = index - 1
-                end_index = index
             if line[0].strip() == '8' and (line[4].strip() == '09' or line[4].strip() == '9') and lodging_transactions_block_start == -1:
                 lodging_transactions_block_start = index + 1
             if line[0].strip() == '9' and (line[4].strip() == '09' or line[4].strip() == '9') and lodging_transactions_block_end == -1:
                 lodging_transactions_block_end = index - 1
-                end_index = index
             if line[0].strip() == '8' and line[4].strip() == '14' and airline_booking_transactions_block_start == -1:
                 airline_booking_transactions_block_start = index + 1
             if line[0].strip() == '9' and line[4].strip() == '14' and airline_booking_transactions_block_end == -1:
                 airline_booking_transactions_block_end = index - 1
-                end_index = index
             if line[0].strip() == '8' and line[4].strip() == '17' and fleet_service_transactions_block_start == -1:
                 fleet_service_transactions_block_start = index + 1
             if line[0].strip() == '9' and line[4].strip() == '17' and fleet_service_transactions_block_end == -1:
                 fleet_service_transactions_block_end = index - 1
-                end_index = index
             if line[0].strip() == '8' and line[4].strip() == '18' and fleet_product_transactions_block_start == -1:
                 fleet_product_transactions_block_start = index + 1
             if line[0].strip() == '9' and line[4].strip() == '18' and fleet_product_transactions_block_end == -1:
                 fleet_product_transactions_block_end = index - 1
-                end_index = index
 
         card_transactions = lines[card_transactions_block_start: card_transactions_block_end + 1]
         car_rental_transactions = lines[car_rental_transactions_block_start:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='card_data_parsers',
-    version='0.14.0',
+    version='0.15.0',
     author='Siva Narayanan',
     author_email='siva@fyle.in',
     url='https://www.fylehq.com',


### PR DESCRIPTION
Problem
- Few transaction for the user did not flow into Fyle.

Triaging notes
- Checked all the statements which were given by the bank, all are parsed, but in some of the statements some of the transactions were not parsed.

Issue
- There were more than one transaction blocks in the statement, and only the first transaction blocks were considered.
But this is expected on our code, even if visa sends multiple transaction blocks we were handling it.

Solution
- Went through the code and doc that we had written for VCF feed parser.
- There was a miss in handling transaction block
- Current code logic, is not writtening the end transaction block (end_index)to iterate through next items, instead it returns transactions additional details end block as end transaction block (end_index) 
PR link [here](https://app.clickup.com/t/85ztdangu)